### PR TITLE
Dockerfile: add Dockerfile to project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          apt-get update && apt-get -y install xz-utils unzip openssl
+          apt-get update && apt-get -y install xz-utils unzip openssl netcat-openbsd
           make test --always-make
 
   generate:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM golang:1.16-alpine3.14 as builder
+
+RUN apk add --update --no-cache ca-certificates tzdata git make bash && update-ca-certificates
+
+ADD . /opt
+WORKDIR /opt
+
+RUN git update-index --refresh; make build
+
+FROM alpine:3.14 as runner
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /opt/thanos-rule-syncer /bin/thanos-rule-syncer
+
+ARG BUILD_DATE
+ARG VERSION
+ARG VCS_REF
+ARG DOCKERFILE_PATH
+
+LABEL vendor="Observatorium" \
+    name="observatorium/thanos-rule-syncer" \
+    description="Thanos Rule Syncer" \
+    io.k8s.display-name="observatorium/thanos-rule-syncer" \
+    io.k8s.description="Thanos Rule Syncer" \
+    maintainer="Observatorium <team-monitoring@redhat.com>" \
+    version="$VERSION" \
+    org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.description="Thanos Rule Syncer" \
+    org.label-schema.docker.cmd="docker run --rm observatorium/thanos-rule-syncer" \
+    org.label-schema.docker.dockerfile=$DOCKERFILE_PATH \
+    org.label-schema.name="observatorium/thanos-rule-syncer" \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.vcs-branch=$VCS_BRANCH \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/observatorium/thanos-rule-syncer" \
+    org.label-schema.vendor="observatorium/thanos-rule-syncer" \
+    org.label-schema.version=$VERSION
+
+ENTRYPOINT ["/bin/thanos-rule-syncer"]

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -117,18 +117,28 @@ echo "-------------------------------------------"
 echo "- Rules File tests                        -"
 echo "-------------------------------------------"
 
-query="$(curl \
-    --fail \
-    'http://127.0.0.1:8443/api/metrics/v1/test-oidc/api/v1/query?query=trs' \
-    -H "Authorization: bearer $token")"
+i=0
+while [ "$i" -lt 10 ]; do
+  query="$(curl \
+      --fail \
+      'http://127.0.0.1:8443/api/metrics/v1/test-oidc/api/v1/query?query=trs' \
+      -H "Authorization: bearer $token")"
+  
+  if [[ "$query" == *'"result":[{"metric":{"__name__":"trs","tenant_id":"1610b0c3-c509-4592-a256-a1871353dbfa"}'* ]]; then
+    result=0
+    break
+  else
+    result=1
+    ((i=i+1))
+    sleep 5
+  fi
+done
 
-if [[ "$query" == *'"result":[{"metric":{"__name__":"trs","tenant_id":"1610b0c3-c509-4592-a256-a1871353dbfa"}'* ]]; then
-  result=0
+if [ "$result" -eq 0 ]; then
   echo "-------------------------------------------"
   echo "- Rules File: OK                          -"
   echo "-------------------------------------------"
 else
-  result=1
   echo "-------------------------------------------"
   echo "- Rules File: FAILED                      -"
   echo "-------------------------------------------"


### PR DESCRIPTION
Right now, no container images are built for this project because it was
not bootstrapped with a Dockerfile. This commit adds a Dockerfile so
that we can build container images. Note: CI is already attempting (and
failing) to build containers.

Currently, querying for the time series produced by the ruler is racey
because the ruler may not yet have had a chance to generate the time
series specified by the recording rules. This raciness can cause the
integration test to occasionally fail. This commit adds retries to the
testing of the rules. Eventually, these integration tests could be
ported to the same e2e test framework used in observatorium/api.

The integration tests are failing in CI because the Golang Docker
container does not have the netcat utility installed, resulting in the
error logs:
```
./test/integration.sh: line 65: nc: command not found
```

This commit adds netcat to fix this problem.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>