### PR TITLE
Add support for fetching rules for multiple tenants

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/campoy/embedmd v1.0.0
 	github.com/coreos/go-oidc v2.2.1+incompatible
+	github.com/ghodss/yaml v1.0.0
 	github.com/observatorium/api v0.1.3-0.20211122104540-940184155779
 	github.com/oklog/run v1.1.0
 	github.com/pquerna/cachecontrol v0.0.0-20201205024021-ac21108117ac // indirect

--- a/instrument.go
+++ b/instrument.go
@@ -19,7 +19,7 @@ func newRoundTripperInstrumenter(r prometheus.Registerer) *roundTripperInstrumen
 				Name: "client_api_requests_total",
 				Help: "A counter for requests from the wrapped client.",
 			},
-			[]string{"code", "method", "client"},
+			[]string{"code", "method", "client", "tenant"},
 		),
 		requestDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -27,7 +27,7 @@ func newRoundTripperInstrumenter(r prometheus.Registerer) *roundTripperInstrumen
 				Help:    "A histogram of request latencies.",
 				Buckets: prometheus.DefBuckets,
 			},
-			[]string{"method", "client"},
+			[]string{"method", "client", "tenant"},
 		),
 	}
 
@@ -42,9 +42,9 @@ func newRoundTripperInstrumenter(r prometheus.Registerer) *roundTripperInstrumen
 }
 
 // NewRoundTripper wraps a HTTP RoundTripper with some metrics.
-func (i *roundTripperInstrumenter) NewRoundTripper(name string, rt http.RoundTripper) http.RoundTripper {
-	counter := i.requestCounter.MustCurryWith(prometheus.Labels{"client": name})
-	duration := i.requestDuration.MustCurryWith(prometheus.Labels{"client": name})
+func (i *roundTripperInstrumenter) NewRoundTripper(name string, tenant string, rt http.RoundTripper) http.RoundTripper {
+	counter := i.requestCounter.MustCurryWith(prometheus.Labels{"client": name, "tenant": tenant})
+	duration := i.requestDuration.MustCurryWith(prometheus.Labels{"client": name, "tenant": tenant})
 
 	return promhttp.InstrumentRoundTripperCounter(counter,
 		promhttp.InstrumentRoundTripperDuration(duration, rt),

--- a/test/config/syncer-tenants.yaml
+++ b/test/config/syncer-tenants.yaml
@@ -1,0 +1,7 @@
+tenants:
+- name: test-oidc
+  oidc:
+    clientID: thanos-rule-syncer
+    clientSecret: secret
+    audience: observatorium
+    issuerURL: http://localhost:4444/

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -94,13 +94,9 @@ echo "-------------------------------------------"
 (
   ./thanos-rule-syncer \
     --observatorium-api-url=http://localhost:8443 \
-    --tenant=test-oidc \
     --thanos-rule-url=http://localhost:10902 \
     --file="$tmp"/rules.yaml \
-    --oidc.issuer-url=http://localhost:4444/ \
-    --oidc.client-id=thanos-rule-syncer \
-    --oidc.client-secret=secret \
-    --oidc.audience=observatorium
+    --tenants.config-file=./test/config/syncer-tenants.yaml
 ) &
 
 echo "-------------------------------------------"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,6 +34,7 @@ github.com/efficientgo/tools/core/pkg/merrors
 # github.com/felixge/httpsnoop v1.0.1
 github.com/felixge/httpsnoop
 # github.com/ghodss/yaml v1.0.0
+## explicit
 github.com/ghodss/yaml
 # github.com/go-chi/chi v4.1.0+incompatible
 github.com/go-chi/chi


### PR DESCRIPTION
Fixes #7 

- [x] Add basic support for fetching rules for multiple tenants.
- [x] Do networks requests to fetch rules concurrently.
- [ ] Handle tenants with invalid configuration gracefully.
- [ ] Instrument skipped/failed tenants with metrics.

Signed-off-by: Prem Saraswat <prmsrswt@gmail.com>