### PR TITLE
main.go: Clarify flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ At last the Thanos Ruler will be reloaded with a POST request against `$(--thano
 ```txt
 Usage of ./thanos-rule-syncer:
   -file string
-    	The path to the file the rules are written to on disk so that Thanos Ruler can read it from.
+    	The path to the file the rules are written to on disk so that Thanos Ruler can read it from. Required. (default "rules.yaml")
   -interval uint
     	The interval at which to poll the Observatorium API for updates to rules, given in seconds. (default 60)
   -observatorium-api-url string
-    	The URL of the Observatorium API from which to fetch the rules.
+    	The URL of the Observatorium API from which to fetch the rules. If specified, auth flags must also be provided.
   -observatorium-ca string
     	Path to a file containing the TLS CA against which to verify the Observatorium API. If no server CA is specified, the client will use the system certificates.
   -oidc.audience string
@@ -29,9 +29,9 @@ Usage of ./thanos-rule-syncer:
   -oidc.issuer-url string
     	The OIDC issuer URL, see https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery.
   -rules-backend-url string
-    	The URL of the Rules Storage Backend from which to fetch the rules. If specified, it gets priority over -observatorium-api-url.
+    	The URL of the Rules Storage Backend from which to fetch the rules. If specified, it gets priority over -observatorium-api-url and auth flags are no longer needed.
   -tenant string
     	The name of the tenant whose rules should be synced.
   -thanos-rule-url string
-    	The URL of Thanos Ruler that is used to trigger reloads of rules. We will append /-/reload.
+    	The URL of Thanos Ruler that is used to trigger reloads of rules. We will append /-/reload. Required.
 ```

--- a/main.go
+++ b/main.go
@@ -41,17 +41,23 @@ type oidcConfig struct {
 
 func parseFlags() *config {
 	cfg := &config{}
-	flag.StringVar(&cfg.rulesBackendURL, "rules-backend-url", "", "The URL of the Rules Storage Backend from which to fetch the rules. If specified, it gets priority over -observatorium-api-url.")
-	flag.StringVar(&cfg.observatoriumURL, "observatorium-api-url", "", "The URL of the Observatorium API from which to fetch the rules.")
+
+	// Common flags.
+	flag.StringVar(&cfg.file, "file", "rules.yaml", "The path to the file the rules are written to on disk so that Thanos Ruler can read it from. Required.")
+	flag.StringVar(&cfg.thanosRuleURL, "thanos-rule-url", "", "The URL of Thanos Ruler that is used to trigger reloads of rules. We will append /-/reload. Required.")
+	flag.UintVar(&cfg.interval, "interval", 60, "The interval at which to poll the Observatorium API for updates to rules, given in seconds.")
+
+	// Use rules backend where no auth is needed and only single instance of thanos-rule-syncer sidecar is required.
+	flag.StringVar(&cfg.rulesBackendURL, "rules-backend-url", "", "The URL of the Rules Storage Backend from which to fetch the rules. If specified, it gets priority over -observatorium-api-url and auth flags are no longer needed.")
+
+	// Use Observatorium API, which requires auth and needs a thanos-rule-syncer sidecar per tenant.
+	flag.StringVar(&cfg.observatoriumURL, "observatorium-api-url", "", "The URL of the Observatorium API from which to fetch the rules. If specified, auth flags must also be provided.")
 	flag.StringVar(&cfg.tenant, "tenant", "", "The name of the tenant whose rules should be synced.")
 	flag.StringVar(&cfg.observatoriumCA, "observatorium-ca", "", "Path to a file containing the TLS CA against which to verify the Observatorium API. If no server CA is specified, the client will use the system certificates.")
-	flag.StringVar(&cfg.thanosRuleURL, "thanos-rule-url", "", "The URL of Thanos Ruler that is used to trigger reloads of rules. We will append /-/reload.")
-	flag.StringVar(&cfg.file, "file", "", "The path to the file the rules are written to on disk so that Thanos Ruler can read it from.")
 	flag.StringVar(&cfg.oidc.issuerURL, "oidc.issuer-url", "", "The OIDC issuer URL, see https://openid.net/specs/openid-connect-discovery-1_0.html#IssuerDiscovery.")
 	flag.StringVar(&cfg.oidc.clientSecret, "oidc.client-secret", "", "The OIDC client secret, see https://tools.ietf.org/html/rfc6749#section-2.3.")
 	flag.StringVar(&cfg.oidc.clientID, "oidc.client-id", "", "The OIDC client ID, see https://tools.ietf.org/html/rfc6749#section-2.3.")
 	flag.StringVar(&cfg.oidc.audience, "oidc.audience", "", "The audience for whom the access token is intended, see https://openid.net/specs/openid-connect-core-1_0.html#IDToken.")
-	flag.UintVar(&cfg.interval, "interval", 60, "The interval at which to poll the Observatorium API for updates to rules, given in seconds.")
 
 	flag.Parse()
 	return cfg


### PR DESCRIPTION
This PR clarifies the flags for thanos-rule-syncer and marks the required flags. Also, clarifies the case where auth flags must be provided. Adds a default for the file flag.

This does not change the flags themselves, only the descriptions, so existing manifests should work.