### PR TITLE
Instrument default HTTP client

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 	registry := prometheus.NewRegistry()
 	roundTripperInst := newRoundTripperInstrumenter(registry)
 
-	ctx, cancel := context.WithCancel(context.Background()) // ADD to context
+	ctx, cancel := context.WithCancel(context.Background())
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	client := &http.Client{
 		Transport: roundTripperInst.NewRoundTripper("thanos-rule-syncer-http", t),

--- a/main.go
+++ b/main.go
@@ -71,12 +71,6 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t := http.DefaultTransport.(*http.Transport).Clone()
-	clientFetcher := &http.Client{
-		Transport: roundTripperInst.NewRoundTripper("fetch", t),
-	}
-	clientReloader := &http.Client{
-		Transport: roundTripperInst.NewRoundTripper("reload", t),
-	}
 
 	if cfg.observatoriumCA != "" {
 		caFile, err := ioutil.ReadFile(cfg.observatoriumCA)
@@ -89,6 +83,13 @@ func main() {
 		t.TLSClientConfig = &tls.Config{
 			RootCAs: certPool,
 		}
+	}
+
+	clientFetcher := &http.Client{
+		Transport: roundTripperInst.NewRoundTripper("fetch", t),
+	}
+	clientReloader := &http.Client{
+		Transport: roundTripperInst.NewRoundTripper("reload", t),
 	}
 
 	if cfg.oidc.issuerURL != "" {
@@ -111,7 +112,7 @@ func main() {
 		}
 		clientFetcher = &http.Client{
 			Transport: &oauth2.Transport{
-				Base:   t,
+				Base:   clientFetcher.Transport,
 				Source: ccc.TokenSource(ctx),
 			},
 		}


### PR DESCRIPTION
This PR instruments also the HTTP client that is used for getting rules, by adding `NewRoundTripper` to `Transport`, but using the client label as `client="thanos-rule-syncer-http"`
Hopefully this will help us to track which requests are successfully synced to Thanos Rule Syncer even if `--oidc.issuer-url` flag is not enabled.
Context: https://github.com/rhobs/configuration/pull/298#issuecomment-1227013288 

Signed-off-by: Jéssica Lins <jessicaalins@gmail.com>