### PR TITLE
Add internal server for metrics + pprof

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,6 @@ Usage of ./thanos-rule-syncer:
     	The name of the tenant whose rules should be synced.
   -thanos-rule-url string
     	The URL of Thanos Ruler that is used to trigger reloads of rules. We will append /-/reload. Required.
+  -web.internal.listen string
+    	The address on which the internal server listens. (default ":8083")
 ```

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/campoy/embedmd v1.0.0
 	github.com/coreos/go-oidc v2.2.1+incompatible
+	github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a
 	github.com/observatorium/api v0.1.3-0.20220105112411-f8b0fbf3eaae
 	github.com/oklog/run v1.1.0
 	github.com/pquerna/cachecontrol v0.0.0-20201205024021-ac21108117ac // indirect


### PR DESCRIPTION
This PR adds an internal server to thanos-rule-syncer which is configured via `--web.internal.listen` flag (default to 8083), and serves metrics and pprof.

This syncer was instrumented, but there were no endpoints from which metrics could be scraped. 